### PR TITLE
Support Theme and hex colors

### DIFF
--- a/Cyborg/VectorDrawable.swift
+++ b/Cyborg/VectorDrawable.swift
@@ -59,7 +59,7 @@ protocol GroupChild: AnyObject {
     
     func createPaths(in size: CGSize) -> [CGPath]
     
-    func layerConfigurations() -> [(CAShapeLayer) -> ()]
+    func layerConfigurations() -> [(CAShapeLayer, Theme) -> ()]
     
 }
 
@@ -115,7 +115,7 @@ public final class VectorDrawable {
         )
     }
     
-    func layerConfigurations() -> [(CAShapeLayer) -> ()] {
+    func layerConfigurations() -> [(CAShapeLayer, Theme) -> ()] {
         return Array(
             groups
                 .map { group in
@@ -157,7 +157,7 @@ public final class VectorDrawable {
             )
         }
         
-        func layerConfigurations() -> [(CAShapeLayer) -> ()] {
+        func layerConfigurations() -> [(CAShapeLayer, Theme) -> ()] {
             return Array(children.map { path in
                 return path.layerConfigurations()
             }
@@ -219,19 +219,24 @@ public final class VectorDrawable {
             for command in data {
                 context = command(context, path, size)
             }
-            print(path)
             return [path]
         }
         
-        func layerConfigurations() -> [(CAShapeLayer) -> ()] {
-            return [apply(to: )]
+        func layerConfigurations() -> [(CAShapeLayer, Theme) -> ()] {
+            return [apply(to: using:)]
         }
         
-        func apply(to layer: CAShapeLayer) {
-            layer.strokeColor = strokeColor?.asUIColor.withAlphaComponent(strokeAlpha).cgColor
+        func apply(to layer: CAShapeLayer, using theme: Theme) {
+            layer.strokeColor = strokeColor?
+                .color(from: theme)
+                .withAlphaComponent(strokeAlpha)
+                .cgColor
             layer.strokeStart = trimPathStart + trimPathOffset
             layer.strokeEnd = trimPathEnd + trimPathOffset
-            layer.fillColor = fillColor?.asUIColor.withAlphaComponent(fillAlpha).cgColor
+            layer.fillColor = fillColor?
+                .color(from: theme)
+                .withAlphaComponent(fillAlpha)
+                .cgColor
             layer.lineCap = strokeLineCap.intoCoreAnimation
             layer.lineJoin = strokeLineJoin.intoCoreAnimation
         }

--- a/Cyborg/VectorView.swift
+++ b/Cyborg/VectorView.swift
@@ -8,6 +8,22 @@ import UIKit
 /// Displays a VectorDrawable.
 open class VectorView: UIView {
     
+    public var theme: Theme {
+        didSet {
+            updateLayers()
+        }
+    }
+    
+    public init(theme: Theme) {
+        self.theme = theme
+        super.init(frame: .zero)
+    }
+    
+    @available(*, unavailable, message: "NSCoder and Interface Builder is not supported. Use Programmatic layout.")
+    public required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     private var drawableLayers: [CALayer] = [] {
         didSet {
             for layer in oldValue {
@@ -36,7 +52,7 @@ open class VectorView: UIView {
     
     private func updateLayers() {
         if let drawable = drawable {
-            drawableLayers = drawable.layerRepresentation(in: bounds)
+            drawableLayers = drawable.layerRepresentation(in: bounds, using: theme)
             drawableSize = drawable.intrinsicSize
         } else {
             drawableLayers = []
@@ -53,7 +69,7 @@ open class VectorView: UIView {
 
 extension VectorDrawable {
     
-    func layerRepresentation(in bounds: CGRect) -> [CALayer] {
+    func layerRepresentation(in bounds: CGRect, using theme: Theme) -> [CALayer] {
         if bounds.width == 0.0 || bounds.height == 0.0 {
             // there is no point in showing anything for a view of size zero
             return []
@@ -64,7 +80,7 @@ extension VectorDrawable {
                        createPaths(in: viewSpace))
                 .map { (configuration, path) in
                     let layer = CAShapeLayer()
-                    configuration(layer)
+                    configuration(layer, theme)
                     layer.path = path
                     layer.frame = bounds
                     return layer
@@ -75,5 +91,11 @@ extension VectorDrawable {
     var intrinsicSize: CGSize {
         return .init(width: baseWidth, height: baseHeight)
     }
+    
+}
+
+public protocol Theme {
+    
+    func color(named string: String) -> UIColor
     
 }

--- a/Cyborg/XMLSchema.swift
+++ b/Cyborg/XMLSchema.swift
@@ -67,32 +67,39 @@ enum Color {
     case hardCoded(UIColor)
     
     init?(_ string: String) {
-        // munge the string into a form that Init.init(_:, radix:) can understand
-        var withoutLeadingHashTag = string.replacingOccurrences(of: "#", with: "")
-        if withoutLeadingHashTag.count == 3 {
-            // convert from shorthand hexadecimal form, which doesn't work with the init
-            withoutLeadingHashTag.append(withoutLeadingHashTag)
-        }
-        if let value = Int(withoutLeadingHashTag, radix: 16) {
-            func component(_ mask: Int, _ shift: Int) -> CGFloat {
-                return CGFloat((value & mask) >> shift) / 255
-            }
-            self = .hex(value: UIColor(red: component(0xFF0000, 16),
-                                       green: component(0xFF00, 8),
-                                       blue: component(0xFF, 0),
-                                       alpha: 1.0))
+        if string.hasPrefix("?") {
+            self = .theme(name: String(string[string.index(after: string.startIndex)..<string.endIndex]))
         } else {
-            print("returning bogus hard coded color")
-            self = .hardCoded(.random)
+            // munge the string into a form that Init.init(_:, radix:) can understand
+            var withoutLeadingHashTag = string
+            _ = withoutLeadingHashTag.remove(at: withoutLeadingHashTag.startIndex)
+            if withoutLeadingHashTag.count == 3 {
+                // convert from shorthand hexadecimal form, which doesn't work with the init
+                withoutLeadingHashTag.append(withoutLeadingHashTag)
+            }
+            if let value = Int(withoutLeadingHashTag, radix: 16) {
+                func component(_ mask: Int, _ shift: Int) -> CGFloat {
+                    return CGFloat((value & mask) >> shift) / 255
+                }
+                self = .hex(value: UIColor(red: component(0xFF0000, 16),
+                                           green: component(0xFF00, 8),
+                                           blue: component(0xFF, 0),
+                                           alpha: 1.0))
+            } else {
+                print("returning bogus hard coded color")
+                self = .hardCoded(.random)
+            }
         }
     }
     
-    var asUIColor: UIColor {
+    func color(from theme: Theme) -> UIColor {
         switch self {
         case .hardCoded(let color):
             return color
         case .hex(let value):
             return value
+        case .theme(let name):
+            return theme.color(named: name)
         default:
             fatalError()
         }

--- a/SampleApp/ViewController.swift
+++ b/SampleApp/ViewController.swift
@@ -5,6 +5,14 @@
 import UIKit
 import Cyborg
 
+class Theme: Cyborg.Theme {
+    
+    func color(named string: String) -> UIColor {
+        return .black
+    }
+    
+}
+
 class ViewController: UIViewController {
     
     override func viewDidLoad() {
@@ -16,7 +24,7 @@ class ViewController: UIViewController {
                 data.data(using: .utf8)!
         }
         for data in drawableData {
-            let vectorView = VectorView(frame: .zero)
+            let vectorView = VectorView(theme: Theme())
             let debugView = DebugDiagnosticsView()
             debugView.attach(to: vectorView)
             view.addSubview(vectorView)


### PR DESCRIPTION
As the title. Theme colors are of the form `?myColorName`, hex colors look like `#33FFFFFF`. 

The hex colors is pretty self explanatory. Theme colors require that the user inits the drawable with a theme. We may want to offer some base theme objects in the future (or give users the ability to init a VectorDrawable without a theme), for now there's a superficial impl in the sample app. 