### PR TITLE
Implements Tint

### DIFF
--- a/CyborgTests/XMLSchemaTests.swift
+++ b/CyborgTests/XMLSchemaTests.swift
@@ -85,7 +85,8 @@ class XMLSchemaTests: XCTestCase {
         let externalValues = ExternalValues(resources: NoTheme(),
                                             theme: NoTheme())
         let layers = drawable.layerRepresentation(in: .boundsRect(24, 24),
-                                                  using: externalValues)
+                                                  using: externalValues,
+                                                  tint: (.src, .clear))
         let pathLayer = layers[0].layerInHierarchy(named: layerName) as! ShapeLayer<VectorDrawable.Path>
         pathLayer.bounds = drawable.intrinsicSize.intoBounds()
         pathLayer.layoutIfNeeded()


### PR DESCRIPTION
Implements Blend Mode, adds a `tint` property to `VectorView` to support this. 

I did it as a tuple because it's easier to use in that format, but it's possible a struct would be better, since that lets us provide some default values for common uses cases.

I also chose not to respect the iOS tint color, even though it's technically more appropriate, to maintain parity with Android. 

Closes #12. 