### PR TITLE
Add Blank VectorDrawable

### DIFF
--- a/Cyborg/VectorDrawable.swift
+++ b/Cyborg/VectorDrawable.swift
@@ -423,6 +423,14 @@ public final class VectorDrawable {
             super.apply(to: layer)
         }
     }
+    
+    /// An empty VectorDrawable of size zero.
+    public static let blank = VectorDrawable(baseWidth: 0,
+                                             baseHeight: 0,
+                                             viewPortWidth: 0,
+                                             viewPortHeight: 0,
+                                             baseAlpha: 0,
+                                             groups: [])
 
 }
 


### PR DESCRIPTION
Add an empty VectorDrawable. Useful for cases where you must provide a drawable and can't pass nil. 