### PR TITLE
Fix incorrect logic for ending elements

### DIFF
--- a/Cyborg/VectorDrawableParser.swift
+++ b/Cyborg/VectorDrawableParser.swift
@@ -127,18 +127,12 @@ public extension VectorDrawable {
             defer {
                 xmlFreeTextReader(xml)
             }
-            var lastElement = ""
             while xmlTextReaderRead(xml) == 1 {
                 let count = xmlTextReaderAttributeCount(xml)
                 if let namePointer = xmlTextReaderConstName(xml) {
                     let elementName = String(cString: namePointer)
                     let isEmpty = xmlTextReaderIsEmptyElement(xml) == 1
                     let type = xmlTextReaderNodeType(xml)
-                    defer {
-                        if type != XML_READER_TYPE_SIGNIFICANT_WHITESPACE.rawValue {
-                            lastElement = elementName
-                        }
-                    }
                     if type == XML_READER_TYPE_SIGNIFICANT_WHITESPACE.rawValue {
                         // we don't care about these, they show up as "#text"
                         // which disrupts the parsing
@@ -146,7 +140,7 @@ public extension VectorDrawable {
                     }
                     if type == XML_READER_TYPE_END_ELEMENT.rawValue {
                         // The return value here indicates whether the parser ended, which we don't care about in this case.
-                        _ = parser.didEnd(element: lastElement)
+                        _ = parser.didEnd(element: elementName)
                         continue
                     }
                     var attributes = [(XMLString, XMLString)]()

--- a/CyborgTests/XMLSchemaTests.swift
+++ b/CyborgTests/XMLSchemaTests.swift
@@ -18,7 +18,7 @@
 import XCTest
 
 class XMLSchemaTests: XCTestCase {
-
+    
     func test_parse_empty_vector() {
         let drawable = VectorDrawable
             .create(from: """
@@ -36,7 +36,7 @@ class XMLSchemaTests: XCTestCase {
         XCTAssertEqual(drawable.baseWidth, 24)
         XCTAssertEqual(drawable.baseHeight, 25)
     }
-
+    
     func test_fail_to_parse_two_vector_elements() {
         let result = VectorDrawable
             .create(from: """
@@ -59,41 +59,41 @@ class XMLSchemaTests: XCTestCase {
         case .ok(let wrapped): XCTFail("\(wrapped)")
         }
     }
-
+    
     func test_nested_groups() {
         let layerName = "PathLayer"
         let drawable = VectorDrawable
             .create(from: """
-            <?xml version="1.0" encoding="utf-8"?>
-            <vector xmlns:android="http://schemas.android.com/apk/res/android"
-            android:width="24dp"
-            android:height="24dp"
-            android:viewportWidth="24"
-            android:viewportHeight="24">
-
-            <group
-            android:translateX="10"
-            android:translateY="10">
-
-            <group
-            android:translateX="-11"
-            android:translateY="-11">
-            <path
-            android:name="\(layerName)"
-            android:pathData="M 1,1 C 1,2 3,3, 4,5z" />
-            </group>
-
-            </group>
-            </vector>
-            """).expectSuccess()
+                <?xml version="1.0" encoding="utf-8"?>
+                <vector xmlns:android="http://schemas.android.com/apk/res/android"
+                android:width="24dp"
+                android:height="24dp"
+                android:viewportWidth="24"
+                android:viewportHeight="24">
+                
+                <group
+                android:translateX="10"
+                android:translateY="10">
+                
+                <group
+                android:translateX="-11"
+                android:translateY="-11">
+                <path
+                android:name="\(layerName)"
+                android:pathData="M 1,1 C 1,2 3,3, 4,5z" />
+                </group>
+                
+                </group>
+                </vector>
+                """).expectSuccess()
         XCTAssert(drawable
             .hierarchyMatches([
                 .group([
                     .group([
                         .path,
+                        ]),
                     ]),
-                ]),
-        ]))
+                ]))
         let externalValues = ExternalValues(resources: NoTheme(),
                                             theme: NoTheme())
         let layers = drawable.layerRepresentation(in: .boundsRect(24, 24),
@@ -109,5 +109,45 @@ class XMLSchemaTests: XCTestCase {
                           control2: .init(x: 2, y: 2))
         expected.closeSubpath()
         XCTAssertEqual(expected.copy()!, pathLayer.path!)
+    }
+    
+    func test_two_nested_groups() {
+        let drawable = VectorDrawable
+            .create(from: """
+                <?xml version="1.0" encoding="utf-8"?>
+                <vector xmlns:android="http://schemas.android.com/apk/res/android"
+                android:viewportWidth="24"
+                android:viewportHeight="24"
+                android:width="24dp"
+                android:height="24dp">
+                <group
+                android:translateX="-3589"
+                android:translateY="-2800">
+                <group
+                android:translateX="3596"
+                android:translateY="2801">
+                <path
+                android:pathData="M0 0l0 3 13 0 0 13 3 0L16 0 0 0Z"
+                android:fillColor="?iconPrimary" />
+                </group>
+                <group
+                android:translateX="3590"
+                android:translateY="2806">
+                <path
+                android:pathData="M0 17L17 17 17 0 0 0 0 17ZM3 3L14 3 14 10 11.5 7.5 9.7 9.3 6.5 6 3 9.5 3 3Z"
+                android:fillColor="?iconPrimary" />
+                </group>
+                </group>
+                </vector>
+                """).expectSuccess()
+        XCTAssert(drawable
+            .hierarchyMatches([
+                .group([
+                    .group([
+                        .path,
+                        ]),
+                    .group([.path])
+                    ]),
+                ]))
     }
 }

--- a/CyborgTests/XMLSchemaTests.swift
+++ b/CyborgTests/XMLSchemaTests.swift
@@ -116,28 +116,28 @@ class XMLSchemaTests: XCTestCase {
             .create(from: """
                 <?xml version="1.0" encoding="utf-8"?>
                 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-                android:viewportWidth="24"
-                android:viewportHeight="24"
-                android:width="24dp"
-                android:height="24dp">
-                <group
-                android:translateX="-3589"
-                android:translateY="-2800">
-                <group
-                android:translateX="3596"
-                android:translateY="2801">
-                <path
-                android:pathData="M0 0l0 3 13 0 0 13 3 0L16 0 0 0Z"
-                android:fillColor="?iconPrimary" />
-                </group>
-                <group
-                android:translateX="3590"
-                android:translateY="2806">
-                <path
-                android:pathData="M0 17L17 17 17 0 0 0 0 17ZM3 3L14 3 14 10 11.5 7.5 9.7 9.3 6.5 6 3 9.5 3 3Z"
-                android:fillColor="?iconPrimary" />
-                </group>
-                </group>
+                        android:viewportWidth="24"
+                        android:viewportHeight="24"
+                        android:width="24dp"
+                        android:height="24dp">
+                  <group
+                      android:translateX="-3589"
+                      android:translateY="-2800">
+                    <group
+                        android:translateX="3596"
+                        android:translateY="2801">
+                      <path
+                          android:pathData="M0 0l0 3 13 0 0 13 3 0L16 0 0 0Z"
+                          android:fillColor="?iconPrimary" />
+                    </group>
+                    <group
+                        android:translateX="3590"
+                        android:translateY="2806">
+                      <path
+                          android:pathData="M0 17L17 17 17 0 0 0 0 17ZM3 3L14 3 14 10 11.5 7.5 9.7 9.3 6.5 6 3 9.5 3 3Z"
+                          android:fillColor="?iconPrimary" />
+                    </group>
+                  </group>
                 </vector>
                 """).expectSuccess()
         XCTAssert(drawable


### PR DESCRIPTION
We used to use the last element to end normal closing elements. But in retrospect that approach was obviously flawed, because a sequence of group-open, path-open, path-close, group-close would have caused it to pass the wrong element to the parser objects (path instead of group). 

The original logic for this was pretty messed up, and one of the consequences was that saving the last element instead of using a "fresh" element from the xml parser actually fixed it for some of the drawables I was using at the time. 

This pull request corrects this issue. 