### PR TITLE
Expose the ability to set the intrinsic size of a VectorDrawable

### DIFF
--- a/Cyborg/VectorDrawable.swift
+++ b/Cyborg/VectorDrawable.swift
@@ -115,6 +115,28 @@ public final class VectorDrawable {
         self.baseAlpha = baseAlpha
         self.groups = groups
     }
+    
+    /// Creates a duplicate of the callee with the specified size.
+    ///
+    /// - parameter size: the size to set the drawable to
+    /// - returns: a new `VectorDrawable` with the specified size.
+    public func withSize(_ size: CGSize) -> VectorDrawable {
+        return .init(baseWidth: size.width,
+                     baseHeight: size.height,
+                     viewPortWidth: viewPortWidth,
+                     viewPortHeight: viewPortHeight,
+                     baseAlpha: baseAlpha,
+                     groups: groups)
+    }
+    
+    /// Creates a duplicate of the callee with its base size multiplied by `multiple`.
+    ///
+    /// - parameter multiple: the number to multiply the starting size by
+    /// - returns: a new `VectorDrawable` with the specified size.
+    public func withSizeMultiple(_ multiple: CGFloat) -> VectorDrawable {
+        return withSize(.init(width: baseWidth * multiple,
+                              height: baseHeight * multiple))
+    }
 
     /// Representation of a <group> element from a VectorDrawable document.
     public class Group: GroupChild {

--- a/SampleApp/DisplayViewController.swift
+++ b/SampleApp/DisplayViewController.swift
@@ -46,7 +46,7 @@ class DisplayView: View {
         let scrollView = UIScrollView()
         scrollView.alwaysBounceVertical = true
         scrollView.translatesAutoresizingMaskIntoConstraints = false
-                vectorView.translatesAutoresizingMaskIntoConstraints = false
+        vectorView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.addSubview(vectorView)
         addSubview(scrollView)
         NSLayoutConstraint


### PR DESCRIPTION
This is allowed on Android, we should support it too. 

There have been a few requests for variations of this internally. Exposing this makes it easier to use VectorDrawables as icons in an `AttributedString`. 