### PR TITLE
Allow Tint Color to be associated with a VectorDrawable

### DIFF
--- a/Cyborg/VectorDrawable.swift
+++ b/Cyborg/VectorDrawable.swift
@@ -106,15 +106,15 @@ public final class VectorDrawable {
     
     /// The tint to apply to the drawable.
     ///
-    /// This tint color is overridden if there is a tint color set on the `VectorView` the
-    /// callee is placed into. 
+    /// This tint color overrides the tint color on the `VectorView` it is
+    /// displayed in. If this tint is `nil` the `VectorView`'s tint is used.
     ///
     /// - note: `tint` is considered external to the VectorDrawable
     /// and won't be updated when `theme` is set, though it will apply to
     /// new values provided by the theme.
     /// It is your responsibility to ensure that changes
     /// to `theme` also change `tint` if appropriate.
-    public let tint: AndroidTint
+    public let tint: AndroidTint?
 
     let groups: [GroupChild]
 
@@ -124,7 +124,7 @@ public final class VectorDrawable {
          viewPortHeight: CGFloat,
          baseAlpha: CGFloat,
          groups: [GroupChild],
-         tint: AndroidTint = (.src, .clear)) {
+         tint: AndroidTint? = nil) {
         self.baseWidth = baseWidth
         self.baseHeight = baseHeight
         self.viewPortWidth = viewPortWidth

--- a/Cyborg/VectorDrawable.swift
+++ b/Cyborg/VectorDrawable.swift
@@ -81,6 +81,10 @@ protocol GroupChild: AnyObject {
 }
 
 /// A VectorDrawable. This can be displayed in a `VectorView`.
+///
+/// You can set the `tint` and `intrinsicSize` of a `VectorDrawable` by using
+/// the `withSize` and `withTint` functions, respectively. `withSizeMultiple` is
+/// also available for cases where you want to preserve the aspect ratio of the drawable.
 public final class VectorDrawable {
 
     /// The intrinsic width in points.
@@ -99,6 +103,18 @@ public final class VectorDrawable {
 
     /// The overall alpha to apply to the drawable.
     public let baseAlpha: CGFloat
+    
+    /// The tint to apply to the drawable.
+    ///
+    /// This tint color is overridden if there is a tint color set on the `VectorView` the
+    /// callee is placed into. 
+    ///
+    /// - note: `tint` is considered external to the VectorDrawable
+    /// and won't be updated when `theme` is set, though it will apply to
+    /// new values provided by the theme.
+    /// It is your responsibility to ensure that changes
+    /// to `theme` also change `tint` if appropriate.
+    public let tint: AndroidTint
 
     let groups: [GroupChild]
 
@@ -107,13 +123,15 @@ public final class VectorDrawable {
          viewPortWidth: CGFloat,
          viewPortHeight: CGFloat,
          baseAlpha: CGFloat,
-         groups: [GroupChild]) {
+         groups: [GroupChild],
+         tint: AndroidTint = (.src, .clear)) {
         self.baseWidth = baseWidth
         self.baseHeight = baseHeight
         self.viewPortWidth = viewPortWidth
         self.viewPortHeight = viewPortHeight
         self.baseAlpha = baseAlpha
         self.groups = groups
+        self.tint = tint
     }
     
     /// Creates a duplicate of the callee with the specified size.
@@ -126,7 +144,8 @@ public final class VectorDrawable {
                      viewPortWidth: viewPortWidth,
                      viewPortHeight: viewPortHeight,
                      baseAlpha: baseAlpha,
-                     groups: groups)
+                     groups: groups,
+                     tint: tint)
     }
     
     /// Creates a duplicate of the callee with its base size multiplied by `multiple`.
@@ -136,6 +155,20 @@ public final class VectorDrawable {
     public func withSizeMultiple(_ multiple: CGFloat) -> VectorDrawable {
         return withSize(.init(width: baseWidth * multiple,
                               height: baseHeight * multiple))
+    }
+    
+    /// Creates a duplicate of the callee with its tint set to `tint`.
+    ///
+    /// - parameter tint: the new tint to use
+    /// - returns: a new `VectorDrawable` with the specified `tint`.
+    public func withTint(_ tint: AndroidTint) -> VectorDrawable {
+        return .init(baseWidth: baseWidth,
+                     baseHeight: baseHeight,
+                     viewPortWidth: viewPortWidth,
+                     viewPortHeight: viewPortHeight,
+                     baseAlpha: baseAlpha,
+                     groups: groups,
+                     tint: tint)
     }
 
     /// Representation of a <group> element from a VectorDrawable document.

--- a/Cyborg/VectorView.swift
+++ b/Cyborg/VectorView.swift
@@ -35,7 +35,7 @@ open class VectorView: UIView {
     /// new values provided by the theme.
     /// It is your responsibility to ensure that changes
     /// to `theme` also change `tint` if appropriate.
-    public var tint: AndroidTint = (.src, .clear) {
+    public var tint: AndroidTint? {
         didSet {
             updateLayers()
         }
@@ -105,7 +105,7 @@ open class VectorView: UIView {
             drawableLayers = drawable.layerRepresentation(in: bounds,
                                                           using: ExternalValues(resources: resources,
                                                                                 theme: theme),
-                                                          tint: tint)
+                                                          tint: tint ?? drawable.tint)
             for layer in drawableLayers {
                 layer.transform = transform
             }

--- a/Cyborg/VectorView.swift
+++ b/Cyborg/VectorView.swift
@@ -30,12 +30,15 @@ open class VectorView: UIView {
     /// set the tint to `(.dst, myColor)`, which will choose
     /// `myColor` instead of the color specified in the xml.
     ///
+    /// This proerty is overridden by the `VectorDrawable`'s `tint` property
+    /// if it has been set. 
+    ///
     /// - note: `tint` is considered external to the VectorDrawable
     /// and won't be updated when `theme` is set, though it will apply to
     /// new values provided by the theme.
     /// It is your responsibility to ensure that changes
     /// to `theme` also change `tint` if appropriate.
-    public var tint: AndroidTint? {
+    public var tint: AndroidTint = (.src, .clear) {
         didSet {
             updateLayers()
         }
@@ -105,7 +108,7 @@ open class VectorView: UIView {
             drawableLayers = drawable.layerRepresentation(in: bounds,
                                                           using: ExternalValues(resources: resources,
                                                                                 theme: theme),
-                                                          tint: tint ?? drawable.tint)
+                                                          tint: drawable.tint ?? tint)
             for layer in drawableLayers {
                 layer.transform = transform
             }


### PR DESCRIPTION
This is useful if a user is working with a predefined library of Drawables, such as our brand icons, and wishes to tint one in a different way before passing into a UI component that doesn't take a tint color with the Drawable. It doesn't make sense to add a new drawable only for the purposes of having a new color. 

This also matches the API available in Android, though it's slightly complicated by the fact that in Android there's no such thing as a VectorDrawableView; The VectorDrawable is itself a View. 