### PR TITLE
Update to Swift 5.1, remove unnecessary returns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ osx_image: xcode11.1
 matrix:
     include:
         - name: "CyborgTests"
-          script: xcodebuild test -project VectorDrawable.xcodeproj -scheme Cyborg -destination 'platform=iOS Simulator,OS=13.1,name=iPhone Xr'
+          script: xcodebuild test -project VectorDrawable.xcodeproj -scheme Cyborg -destination 'platform=iOS Simulator,OS=13.1,name=iPhone 11'
         - name: "BuildSampleApp"
-          script: xcodebuild build -project VectorDrawable.xcodeproj -scheme VectorDrawable -destination 'platform=iOS Simulator,OS=13.1,name=iPhone Xr'
+          script: xcodebuild build -project VectorDrawable.xcodeproj -scheme VectorDrawable -destination 'platform=iOS Simulator,OS=13.1,name=iPhone 11'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ osx_image: xcode11.1
 matrix:
     include:
         - name: "CyborgTests"
-          script: xcodebuild test -project VectorDrawable.xcodeproj -scheme Cyborg -destination 'platform=iOS Simulator,OS=11.4,name=iPhone X'
+          script: xcodebuild test -project VectorDrawable.xcodeproj -scheme Cyborg -destination 'platform=iOS Simulator,OS=13.1,name=iPhone Xr'
         - name: "BuildSampleApp"
-          script: xcodebuild build -project VectorDrawable.xcodeproj -scheme VectorDrawable -destination 'platform=iOS Simulator,OS=11.4,name=iPhone X'
+          script: xcodebuild build -project VectorDrawable.xcodeproj -scheme VectorDrawable -destination 'platform=iOS Simulator,OS=13.1,name=iPhone Xr'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
+
 language: objective-c
-osx_image: xcode10.1
+osx_image: xcode11.1
 matrix:
     include:
         - name: "CyborgTests"

--- a/Cyborg/Arc.swift
+++ b/Cyborg/Arc.swift
@@ -26,15 +26,15 @@ struct EllipticArc {
 
     func point(for pseudoAngle: CGFloat) -> CGPoint {
         // 2.2.1 (3)
-        return .init(
+        .init(
             x: center.x + radius.x * cos(xAngle) * cos(pseudoAngle) - radius.y * sin(xAngle) * sin(pseudoAngle),
             y: center.y + radius.x * sin(xAngle) * cos(pseudoAngle) + radius.y * cos(xAngle) * sin(pseudoAngle)
         )
     }
-
+    
     func derivative(for pseudoAngle: CGFloat) -> CGPoint {
         // 2.2.1 (4)
-        return .init(
+        .init(
             x: -radius.x * cos(xAngle) * sin(pseudoAngle) - radius.y * sin(xAngle) * cos(pseudoAngle),
             y: -radius.x * sin(xAngle) * sin(pseudoAngle) + radius.y * cos(xAngle) * cos(pseudoAngle)
         )
@@ -153,10 +153,10 @@ fileprivate struct Segments: Sequence {
     }
 
     func makeIterator() -> Segments.Iterator {
-        return Iterator(current: start,
-                        currentIndex: 0,
-                        delta: delta,
-                        division: division)
+        Iterator(current: start,
+                 currentIndex: 0,
+                 delta: delta,
+                 division: division)
     }
 
     struct Iterator: IteratorProtocol {

--- a/Cyborg/DrawingCommand.swift
+++ b/Cyborg/DrawingCommand.swift
@@ -445,31 +445,31 @@ let allDrawingCommands: [Parser<PathSegment>] = [
 extension CGPoint {
 
     func add(_ rhs: CGPoint) -> CGPoint {
-        return .init(x: x + rhs.x, y: y + rhs.y)
+        .init(x: x + rhs.x, y: y + rhs.y)
     }
 
     func subtract(_ rhs: CGPoint) -> CGPoint {
-        return .init(x: x - rhs.x, y: y - rhs.y)
+        .init(x: x - rhs.x, y: y - rhs.y)
     }
 
     func times(_ x1: CGFloat, _ y1: CGFloat) -> CGPoint {
-        return .init(x: x * x1, y: y * y1)
+        .init(x: x * x1, y: y * y1)
     }
 
     func times(_ size: CGSize) -> CGPoint {
-        return .init(x: x * size.width, y: y * size.height)
+        .init(x: x * size.width, y: y * size.height)
     }
 
     func times(_ other: CGFloat) -> CGPoint {
-        return .init(x: x * other, y: y * other)
+        .init(x: x * other, y: y * other)
     }
 
     func times(_ other: CGPoint) -> CGPoint {
-        return times(other.x, other.y)
+        times(other.x, other.y)
     }
 
     func dot(_ other: CGPoint) -> CGFloat {
-        return (x * other.x) + (y * other.y)
+        (x * other.x) + (y * other.y)
     }
 
     func reflected(across current: CGPoint) -> CGPoint {
@@ -488,7 +488,7 @@ extension CGPoint {
     }
     
     func isWithinAPointOf(_ other: CGPoint) -> Bool {
-        return abs(x - other.x) < 1.0 &&
+        abs(x - other.x) < 1.0 &&
             abs(y - other.y) < 1.0
     }
     

--- a/Cyborg/VectorDrawable.swift
+++ b/Cyborg/VectorDrawable.swift
@@ -139,13 +139,13 @@ public final class VectorDrawable {
     /// - parameter size: the size to set the drawable to
     /// - returns: a new `VectorDrawable` with the specified size.
     public func withSize(_ size: CGSize) -> VectorDrawable {
-        return .init(baseWidth: size.width,
-                     baseHeight: size.height,
-                     viewPortWidth: viewPortWidth,
-                     viewPortHeight: viewPortHeight,
-                     baseAlpha: baseAlpha,
-                     groups: groups,
-                     tint: tint)
+        .init(baseWidth: size.width,
+              baseHeight: size.height,
+              viewPortWidth: viewPortWidth,
+              viewPortHeight: viewPortHeight,
+              baseAlpha: baseAlpha,
+              groups: groups,
+              tint: tint)
     }
     
     /// Creates a duplicate of the callee with its base size multiplied by `multiple`.
@@ -153,8 +153,8 @@ public final class VectorDrawable {
     /// - parameter multiple: the number to multiply the starting size by
     /// - returns: a new `VectorDrawable` with the specified size.
     public func withSizeMultiple(_ multiple: CGFloat) -> VectorDrawable {
-        return withSize(.init(width: baseWidth * multiple,
-                              height: baseHeight * multiple))
+        withSize(.init(width: baseWidth * multiple,
+                       height: baseHeight * multiple))
     }
     
     /// Creates a duplicate of the callee with its tint set to `tint`.
@@ -162,13 +162,13 @@ public final class VectorDrawable {
     /// - parameter tint: the new tint to use
     /// - returns: a new `VectorDrawable` with the specified `tint`.
     public func withTint(_ tint: AndroidTint) -> VectorDrawable {
-        return .init(baseWidth: baseWidth,
-                     baseHeight: baseHeight,
-                     viewPortWidth: viewPortWidth,
-                     viewPortHeight: viewPortHeight,
-                     baseAlpha: baseAlpha,
-                     groups: groups,
-                     tint: tint)
+        .init(baseWidth: baseWidth,
+              baseHeight: baseHeight,
+              viewPortWidth: viewPortWidth,
+              viewPortHeight: viewPortHeight,
+              baseAlpha: baseAlpha,
+              groups: groups,
+              tint: tint)
     }
 
     /// Representation of a <group> element from a VectorDrawable document.
@@ -257,8 +257,8 @@ public final class VectorDrawable {
                           drawableSize: CGSize,
                           transform: [Transform],
                           tint: AndroidTint) -> [CALayer] {
-            return [createLayer(drawableSize: drawableSize,
-                                transform: transform)]
+            [createLayer(drawableSize: drawableSize,
+                         transform: transform)]
         }
 
     }
@@ -504,7 +504,7 @@ public final class VectorDrawable {
 extension UIColor {
     
     func multiplyAlpha(with other: CGFloat) -> UIColor {
-        return withAlphaComponent(alpha * other)
+        withAlphaComponent(alpha * other)
     }
     
     var alpha: CGFloat {
@@ -529,11 +529,11 @@ extension UIColor {
 extension Array where Element == Transform {
 
     func apply(to path: CGPath, relativeTo size: CGSize) -> CGPath {
-        return reduce(path) { path, transform in
+        reduce(path) { path, transform in
             transform.apply(to: path, relativeTo: size)
         }
     }
-
+    
 }
 
 /// A rigid body transformation as specced by VectorDrawable.
@@ -622,14 +622,14 @@ extension BlendMode {
         let (sr, sg, sb, sa) = src.rgba
         let (dr, dg, db, da) = dst.rgba
         func clamp(_ float: CGFloat) -> CGFloat {
-            return max(0, min(float, 1))
+            max(0, min(float, 1))
         }
         func createColor(_ color: (CGFloat, CGFloat) -> CGFloat,
                          _ alpha: (CGFloat, CGFloat) -> CGFloat) -> UIColor {
-            return UIColor(red: clamp(color(sr, dr)),
-                           green: clamp(color(sg, dg)),
-                           blue: clamp(color(sb, db)),
-                           alpha: clamp(alpha(sa, da)))
+            UIColor(red: clamp(color(sr, dr)),
+                    green: clamp(color(sg, dg)),
+                    blue: clamp(color(sb, db)),
+                    alpha: clamp(alpha(sa, da)))
         }
         switch self {
         case .add:

--- a/Cyborg/VectorDrawableParser.swift
+++ b/Cyborg/VectorDrawableParser.swift
@@ -211,23 +211,23 @@ fileprivate func assign<T>(_ string: XMLString,
 
 fileprivate func assign<T>(_ string: XMLString,
                            to property: inout T?) -> ParseError? where T: XMLStringRepresentable {
-    return assign(string, to: &property, creatingWith: T.init(_: ))
+    assign(string, to: &property, creatingWith: T.init(_: ))
 }
 
 fileprivate func assign<T>(_ string: XMLString,
                            to property: inout T) -> ParseError? where T: XMLStringRepresentable {
-    return assign(string, to: &property, creatingWith: T.init(_: ))
+    assign(string, to: &property, creatingWith: T.init(_: ))
 }
 
 
 fileprivate func assignFloat(_ string: XMLString,
                              to path: inout CGFloat?) -> ParseError? {
-    return assign(string, to: &path, creatingWith: CGFloat.init)
+    assign(string, to: &path, creatingWith: CGFloat.init)
 }
 
 fileprivate func assignFloat(_ string: XMLString,
                              to path: inout CGFloat) -> ParseError? {
-    return assign(string, to: &path, creatingWith: CGFloat.init)
+    assign(string, to: &path, creatingWith: CGFloat.init)
 }
 
 protocol NodeParsing: AnyObject {
@@ -301,7 +301,7 @@ class ParentParser<Child>: NodeParsing where Child: NodeParsing {
     }
 
     func parseAttributes(_: [(XMLString, XMLString)]) -> ParseError? {
-        return nil
+        nil
     }
 
     func appendChild(_ child: Child) {
@@ -309,7 +309,7 @@ class ParentParser<Child>: NodeParsing where Child: NodeParsing {
     }
 
     func childForElement(_: String) -> (Child, (Child) -> ())? {
-        return nil
+        nil
     }
 
     func didEnd(element: String) -> Bool {
@@ -423,7 +423,7 @@ final class PathParser: ParentParser<GradientParser>, GroupChildParser {
     static let name: Element = .path
     
     override var name: Element {
-        return .path
+        .path
     }
 
     var pathName: String?
@@ -600,7 +600,7 @@ final class ClipPathParser: NodeParsing, GroupChildParser {
     }
 
     func didEnd(element _: String) -> Bool {
-        return true
+        true
     }
 
     func createElement() -> Result<VectorDrawable.ClipPath> {
@@ -626,15 +626,15 @@ final class AnyGroupParserChild: GroupChildParser {
     }
 
     func parse(element: String, attributes: [(XMLString, XMLString)]) -> ParseError? {
-        return parser.parse(element: element, attributes: attributes)
+        parser.parse(element: element, attributes: attributes)
     }
 
     func didEnd(element: String) -> Bool {
-        return parser.didEnd(element: element)
+        parser.didEnd(element: element)
     }
 
     func createElement(in viewportSize: CGSize) -> Result<GroupChild> {
-        return parser.createElement(in: viewportSize)
+        parser.createElement(in: viewportSize)
     }
 
 }
@@ -694,7 +694,7 @@ final class GroupParser: ParentParser<AnyGroupParserChild>, GroupChildParser {
     }
 
     func createElement(in viewportSize: CGSize) -> Result<GroupChild> {
-        return children.mapAllOrFail { parser in
+        children.mapAllOrFail { parser in
             parser.createElement(in: viewportSize)
         }
         .flatMap { childElements in
@@ -708,7 +708,7 @@ final class GroupParser: ParentParser<AnyGroupParserChild>, GroupChildParser {
                                                                   translation: .init(x: translationX, y: translationY)),
                                              children: childElements,
                                              clipPaths: clipPaths))
-                }
+            }
         }
     }
 
@@ -800,7 +800,7 @@ class GradientParser: NodeParsing {
     }
     
     func didEnd(element: String) -> Bool {
-        return element == androidResourceAttribute
+        element == androidResourceAttribute
     }
     
     

--- a/Cyborg/VectorView.swift
+++ b/Cyborg/VectorView.swift
@@ -181,7 +181,7 @@ open class VectorView: UIView {
     }
 
     open override var intrinsicContentSize: CGSize {
-        return drawableSize
+        drawableSize
     }
     
     open override var contentMode: UIView.ContentMode {
@@ -228,11 +228,11 @@ struct ExternalValues {
     let theme: ThemeProviding
 
     func colorFromTheme(named name: String) -> UIColor {
-        return theme.colorFromTheme(named: name)
+        theme.colorFromTheme(named: name)
     }
 
     func colorFromResources(named name: String) -> UIColor {
-        return resources.colorFromResources(named: name)
+        resources.colorFromResources(named: name)
     }
 
 }
@@ -257,7 +257,7 @@ extension VectorDrawable {
     }
 
     var intrinsicSize: CGSize {
-        return .init(width: baseWidth, height: baseHeight)
+        .init(width: baseWidth, height: baseHeight)
     }
 
 }
@@ -439,13 +439,13 @@ final class ThemeableGradientLayer: CAGradientLayer {
 extension CGSize {
         
     func scaleAspectFit(in dimensions: CGSize) -> CGSize {
-        return scaledToAspect(in: dimensions,
-                              with: min)
+        scaledToAspect(in: dimensions,
+                       with: min)
     }
     
     func scaleAspectFill(in dimensions: CGSize) -> CGSize {
-        return scaledToAspect(in: dimensions,
-                              with: max)
+        scaledToAspect(in: dimensions,
+                       with: max)
     }
     
     private func scaledToAspect(in dimensions: CGSize,

--- a/CyborgTests/GradientTests.swift
+++ b/CyborgTests/GradientTests.swift
@@ -78,7 +78,7 @@ extension VectorDrawable.Gradient.Offset: Equatable {
     
     public static func ==(lhs: VectorDrawable.Gradient.Offset,
                           rhs: VectorDrawable.Gradient.Offset) -> Bool {
-        return lhs.amount == rhs.amount && lhs.color == rhs.color
+        lhs.amount == rhs.amount && lhs.color == rhs.color
     }
     
 }

--- a/SampleApp/Theme.swift
+++ b/SampleApp/Theme.swift
@@ -20,7 +20,7 @@ import Cyborg
 final class Theme: ColorProvider, Cyborg.ThemeProviding {
     
     func colorFromTheme(named name: String) -> UIColor {
-        return colorForKey(name)
+        colorForKey(name)
     }
     
 }
@@ -28,7 +28,7 @@ final class Theme: ColorProvider, Cyborg.ThemeProviding {
 final class Resources: ColorProvider, ResourceProviding {
     
     func colorFromResources(named name: String) -> UIColor {
-        return colorForKey(name)
+        colorForKey(name)
     }
     
 }

--- a/VectorDrawable.xcodeproj/project.pbxproj
+++ b/VectorDrawable.xcodeproj/project.pbxproj
@@ -693,7 +693,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = uber.SampleApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -709,7 +709,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = uber.SampleApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Update to Swift 5.1. Also remove many now-unnecessary return keywords. 