### PR TITLE
Fix two MacOS bugs

### DIFF
--- a/Cyborg/VectorDrawable.swift
+++ b/Cyborg/VectorDrawable.swift
@@ -524,15 +524,39 @@ extension UIColor {
     }
     
     var alpha: CGFloat {
+        // iOS seems to automatically convert this, MacOS does not
+        #if os(iOS)
         var alpha: CGFloat = 0
         getRed(nil, green: nil, blue: nil, alpha: &alpha)
         return alpha
+        #else
+        if let rgb = usingColorSpace(.sRGB) {
+            var alpha: CGFloat = 0
+            rgb.getRed(nil, green: nil, blue: nil, alpha: &alpha)
+            return alpha
+        } else {
+            assertionFailure("Couldn't convert a color to rgb.")
+            return 1
+        }
+        #endif
     }
     
     var rgba: (CGFloat, CGFloat, CGFloat, CGFloat) {
+        // iOS seems to automatically convert this, MacOS does not
+        #if os(iOS)
         var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
         getRed(&r, green: &g, blue: &b, alpha: &a)
         return (r, g, b, a)
+        #else
+        if let rgb = usingColorSpace(.sRGB) {
+            var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+            rgb.getRed(&r, green: &g, blue: &b, alpha: &a)
+            return (r, g, b, a)
+        } else {
+            assertionFailure("Couldn't convert a color to rgb.")
+            return (1, 1, 1, 1)
+        }
+        #endif
     }
     
     func tintedWith(_ tint: AndroidTint) -> UIColor {

--- a/Cyborg/VectorView.swift
+++ b/Cyborg/VectorView.swift
@@ -56,6 +56,7 @@ open class VectorView: NSView {
     open var drawable: VectorDrawable? {
         didSet {
             updateLayers()
+            needsLayout = true
             invalidateIntrinsicContentSize()
         }
     }

--- a/CyborgTests/ColorTests.swift
+++ b/CyborgTests/ColorTests.swift
@@ -105,5 +105,17 @@ class ColorTests: XCTestCase {
             }
         }
     }
+    
+    func test_get_components() {
+        let alpha: CGFloat = 1
+        let greyscaleColor = UIColor(white: 0.5,
+                                     alpha: alpha)
+        XCTAssertEqual(greyscaleColor.alpha, alpha)
+        let hsvColor = UIColor(hue: 0.5,
+                               saturation: 0.5,
+                               brightness: 0.1,
+                               alpha: 1)
+        XCTAssertEqual(hsvColor.alpha, alpha)
+    }
 
 }


### PR DESCRIPTION
There were two bugs left open after @ashare80's pr adding MacOS support was merged: 
- the layers weren't laid out after the drawable was set. I can't recall if `invalidateIntrinsicContentSize()`  was there before I made that comment, so I'm gonna add a `needsLayout = true` call to make sure
- `NSColor`s need to be manually converted to the right color space before calling `getRed(blue: green: alpha:)` or they will assert. 

This pr addresses both those issues. 